### PR TITLE
feat(ansible): optimize HAProxy service management in playbook

### DIFF
--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -46,6 +46,18 @@
         state: present
   when: ansible_facts['distribution'] == "Debian"
 
+- name: Check if haproxy is already installed
+  stat:
+    path: /etc/haproxy/haproxy.cfg
+  register: haproxy_installed
+
+- name: Check the current state of haproxy service
+  systemd:
+    name: haproxy
+    state: started
+  register: haproxy_service
+  failed_when: false
+  changed_when: false
 
 - name: actually installing haproxy
   package:
@@ -65,12 +77,26 @@
   command: "haproxy -f /etc/haproxy/haproxy.cfg -c"
   when: ansible_os_family in ['RedHat', 'Rocky']
 
-- name: restarting haproxy service
+- name: Ensure haproxy is enabled and running if installed
+  systemd:
+    name: haproxy
+    enabled: yes
+    state: started
+  when: haproxy_installed.stat.exists and haproxy_service.status != 0
+
+- name: Restart haproxy if not previously installed
   systemd:
     daemon_reload: yes
     name: haproxy
     enabled: yes
     state: restarted
+  when: not haproxy_installed.stat.exists
+
+- name: Reload haproxy if already installed and running
+  systemd:
+    name: haproxy
+    state: reloaded
+  when: haproxy_installed.stat.exists and haproxy_service.status == 0
 
 - name: Check if port 6443 is open
   wait_for:


### PR DESCRIPTION

This PR introduces optimized tasks for managing the HAProxy service in the Ansible playbook.

#### Changes:
1. **Check HAProxy installation**
   - Verified the existence of `/etc/haproxy/haproxy.cfg`.
   - Registered the result to determine if HAProxy is installed.

2. **Check current state of HAProxy service**
   - Used the `systemd` module to check if the HAProxy service is started.
   - Registered the service status for conditional operations.

3. **Ensure HAProxy is enabled and running**
   - Added a task to enable and start HAProxy if it is installed but not currently running.

4. **Restart HAProxy if not previously installed**
   - Implemented a task to restart HAProxy with daemon reload if it was not previously installed.

5. **Reload HAProxy if already installed and running**
   - Added a task to reload HAProxy to apply configuration changes if it is already installed and running.

#### Rationale:
These changes improve the robustness and reliability of the HAProxy service management by:
- Ensuring that the service is properly enabled and started when required.
- Reducing redundancy in task execution.
- Handling different states of the HAProxy service more accurately to prevent potential downtimes and inconsistencies.

### Closing the Issue with PR

#### Closing Issue:
Closes #90 
