### PR TITLE
fix(roles): improve kubelet configuration logic during the upgrade

### DIFF
--- a/examples/playbooks/56.upgrade-worker-nodes.yml
+++ b/examples/playbooks/56.upgrade-worker-nodes.yml
@@ -24,13 +24,6 @@
   tasks:
     - name: Upgrade kubelet config
       shell: "kubeadm upgrade node"
-    - name: Check that the kubeletconfiguration.yaml exists
-      stat:
-        path: /var/lib/kubelet/kubelet-config/patches/kubeletconfiguration.yaml
-      register: kubeletconfiguration_result
-    - name: Apply kubelet patches
-      shell: "kubeadm upgrade node phase kubelet-config --patches /var/lib/kubelet/kubelet-config/patches/"
-      when: kubeletconfiguration_result.stat.exists
 
 - name: Kubelet and Containerd upgrade
   hosts: nodes
@@ -40,9 +33,11 @@
   roles:
     - kube-node-common
     - containerd
+    - kube-worker
   tags:
     - kube-node-common
     - containerd
+    - kube-worker
 
 - name: Kubernetes uncordon node
   hosts: nodes

--- a/roles/kube-control-plane/handlers/kubelet_checks.yml
+++ b/roles/kube-control-plane/handlers/kubelet_checks.yml
@@ -1,0 +1,23 @@
+---
+# The ansible.builtin.systemd state parameter value doesn't check if the service is active
+# so if the kubelet service is in activating state the task will succede. But if there is an
+# error in the kubelet config.yaml file, the kubelet will remain in activating state and not working even
+# the node seems to be ready.
+- name: Check if kubelet is active
+  ansible.builtin.command: "systemctl is-active kubelet"
+  retries: 3
+  delay: 5
+  changed_when: kubelet_active_status.rc != 0
+  register: kubelet_active_status
+  ignore_errors: true
+
+- name: Get kubelet logs
+  ansible.builtin.command: "journalctl -u kubelet --lines 15 --no-pager"
+  register: kubelet_logs
+  changed_when: kubelet_logs.rc != 0
+  when: kubelet_active_status.rc != 0
+
+- name: Print kubelet logs
+  ansible.builtin.fail:
+    msg: "The kubelet service has not become active in 15 seconds, here are the last 15 lines of logs: \n{{ kubelet_logs.stdout }}"
+  when: kubelet_active_status.rc != 0

--- a/roles/kube-control-plane/handlers/main.yml
+++ b/roles/kube-control-plane/handlers/main.yml
@@ -12,7 +12,6 @@
     name: kubelet
     state: restarted
     daemon_reload: true
-  register: kubelet_status
   listen: Restart kubelet
 
 - name: Kubelet verifications

--- a/roles/kube-control-plane/handlers/main.yml
+++ b/roles/kube-control-plane/handlers/main.yml
@@ -12,4 +12,9 @@
     name: kubelet
     state: restarted
     daemon_reload: true
+  register: kubelet_status
   listen: Restart kubelet
+
+- name: Kubelet verifications
+  ansible.builtin.include_tasks: kubelet_checks.yml
+  listen: Kubelet verifications

--- a/roles/kube-control-plane/tasks/reconfigure-kubelet.yml
+++ b/roles/kube-control-plane/tasks/reconfigure-kubelet.yml
@@ -27,3 +27,4 @@
   notify:
     - Apply kubelet-config patches
     - Restart kubelet
+    - Kubelet verifications

--- a/roles/kube-control-plane/tasks/upgrade.yml
+++ b/roles/kube-control-plane/tasks/upgrade.yml
@@ -35,4 +35,5 @@
   notify:
     - Apply kubelet-config patches
     - Restart kubelet
+    - Kubelet verifications
   when: kubernetes_version is version('1.30.0', 'ge', version_type='semver')

--- a/roles/kube-worker/handlers/kubelet_checks.yml
+++ b/roles/kube-worker/handlers/kubelet_checks.yml
@@ -1,0 +1,23 @@
+---
+# The ansible.builtin.systemd state parameter value doesn't check if the service is active
+# so if the kubelet service is in activating state the task will succede. But if there is an
+# error in the kubelet config.yaml file, the kubelet will remain in activating state and not working even
+# the node seems to be ready.
+- name: Check if kubelet is active
+  ansible.builtin.command: "systemctl is-active kubelet"
+  retries: 3
+  delay: 5
+  changed_when: kubelet_active_status.rc != 0
+  register: kubelet_active_status
+  ignore_errors: true
+
+- name: Get kubelet logs
+  ansible.builtin.command: "journalctl -u kubelet --lines 15 --no-pager"
+  register: kubelet_logs
+  changed_when: kubelet_logs.rc != 0
+  when: kubelet_active_status.rc != 0
+
+- name: Print kubelet logs
+  ansible.builtin.fail:
+    msg: "The kubelet service has not become active in 15 seconds, here are the last 15 lines of logs: \n{{ kubelet_logs.stdout }}"
+  when: kubelet_active_status.rc != 0

--- a/roles/kube-worker/handlers/main.yml
+++ b/roles/kube-worker/handlers/main.yml
@@ -10,4 +10,9 @@
     name: kubelet
     state: restarted
     daemon_reload: true
+  register: kubelet_status
   listen: Restart kubelet
+
+- name: Kubelet verifications
+  ansible.builtin.include_tasks: kubelet_checks.yml
+  listen: Kubelet verifications

--- a/roles/kube-worker/handlers/main.yml
+++ b/roles/kube-worker/handlers/main.yml
@@ -10,7 +10,6 @@
     name: kubelet
     state: restarted
     daemon_reload: true
-  register: kubelet_status
   listen: Restart kubelet
 
 - name: Kubelet verifications

--- a/roles/kube-worker/tasks/reconfigure-kubelet.yml
+++ b/roles/kube-worker/tasks/reconfigure-kubelet.yml
@@ -26,3 +26,4 @@
   notify:
     - Apply kubelet-config patches
     - Restart kubelet
+    - Kubelet verifications


### PR DESCRIPTION
### Summary 💡

As per title, with this PR we improve kubelet reconfiguration logic and:

- Add tasks for verifying kubelet status after applying patches
- Add logic to check if the kubelet service is active
- Ensure that failures are properly reported if kubelet doesn't work


### Description 📝

None.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested the changes with an upgrade from KFD 1.31.0 to 1.31.1 (rc)
- [x] Tested an upgrade without furyctl from K8s 1.31.4 to 1.31.7


### Future work 🔧

None.