### PR TITLE
fix(kube-control-plane): apply patches in legacy kubeadm upgrade

### DIFF
--- a/roles/kube-control-plane/tasks/upgrade.yml
+++ b/roles/kube-control-plane/tasks/upgrade.yml
@@ -13,7 +13,7 @@
   when: kubernetes_version is version('1.29.0', 'ge', version_type='semver')
 
 - name: Upgrade kubernetes master with kubeadm (legacy)
-  ansible.builtin.command: kubeadm upgrade apply --config /etc/kubernetes/kubeadm.yml -y
+  ansible.builtin.command: "kubeadm upgrade apply --config {{ kubeadm_config_file }} -y --patches {{ kubeadm_patches_path }}"
   when: kubernetes_version is version('1.30.0', 'lt', version_type='semver')
 
 - name: Ensuring kubeadm-upgrade-config.yml config file is present on machine


### PR DESCRIPTION
Being that:
1. We dropped the bind-address configuration from the kubeadm configuration and we move it to kubeadm patches files.
3. kubeadm legacy (k8s < 1.30) does not support the UpgradeConfiguration object to specify the upgrade commands flags

We need to pass explicitly the `--patches` flag to the legacy `kubeadm upgrade` command

- [x] tested with custom upgrade path from 1.28.3 to 1.29.7
- [x] tested with custom upgrade path from 1.29.4 to 1.29.7

Without this fix, the kube-scheduler and kube-controller-manager pods will have 127.0.0.1 as bind address and host of the probes.

With this fix, the bind-address flag and probes host are properly set (patches are applied)