### PR TITLE
fix(kube-node-common): run task if compatible

### DIFF
--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -67,6 +67,7 @@
         state: present
 
     - name: Add disclaimer in repository file
+      when: ansible_version.major >= 2 and ansible_version.minor >= 16
       ansible.builtin.blockinfile:
         append_newline: true
         block: "# This file is managed by the On Premises installer of the Kubernetes Fury Distribution.\n# Do not manually edit this file. Content will be replaced each time you run the installer."
@@ -75,7 +76,7 @@
         marker_begin: "- DISCLAIMER START"
         marker_end: "- DISCLAIMER END"
         path: "{{ apt_sources_dir }}/{{ filename }}.list"
-      
+
     - name: Update APT cache
       apt:
         update_cache: true


### PR DESCRIPTION
Add Ansible version check for disclaimer blockinfile task, [that uses a parameter added in ansible 2.16](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/blockinfile_module.html#parameter-append_newline).

Being that this task is not critical, we run it only if the version of Ansible is compatible, otherwise the task fails blocking the whole cluster creation / update process.

Fixes #130 

Tested:
- [x] Replicated the issue from a `debian:12-slim` docker container as "bastion", with ansible-core version 2.14.18 and Python 3.11, against a single node cluster running Ubuntu Focal (python 3.8).
- [x] Tested the fix from a `debian:12-slim` docker container as "bastion", with ansible-core version 2.14.18 and Python 3.11, against a single node cluster running Ubuntu Focal (python 3.8). Created a single master cluster successfully.
- [x] Re-run the furyctl apply command from a different machine with a more recent version of Asnible and verified that the disclaimer was added.