### PR TITLE
fix: ensure gnupg package is present in Debian machines

### DIFF
--- a/roles/kube-node-common/tasks/repo-Debian.yml
+++ b/roles/kube-node-common/tasks/repo-Debian.yml
@@ -5,9 +5,11 @@
     repo: "{{ kubernetes_repo_deprecated['apt_repo'] }}"
     state: absent
 
-- name: Install apt-transport-https
+- name: Install apt-transport-https and gnupg
   apt:
-    name: apt-transport-https
+    pkg: 
+    - apt-transport-https
+    - gnupg
     state: latest
 
 - name: Add Kubernetes APT repository


### PR DESCRIPTION
### Summary 💡

This PR addresses an issue with Debian machines where installations fail because the `gpg` executable is missing.

Closes #65 

### Description 📝

See above.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Tested a clean installation with furyctl with a custom distro-location pointing to this branch, with a Debian 12 machine which did not have `gnupg`
- [x] Verified that the `gnupg` package name is the same in Ubuntu


### Future work 🔧

None.