### PR TITLE
fix(containerd): don't configure default mirror for docker.io

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,46 @@
+# On Premises module release vTBD
+
+Welcome to the latest release of `on-premises` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by SIGHUP by ReeVo team.
+
+This release .... TBD
+
+## Package Versions 🚢
+
+### vTBD
+
+| Package                                        | Supported Version | Previous Version |
+| ---------------------------------------------- | ----------------- | ---------------- |
+| [etcd](roles/etcd)                             | `3.5.16`          | `No update`      |
+| [haproxy](roles/haproxy)                       | `3.0`             | `No update`      |
+| [containerd](roles/containerd)                 | `1.7.26`          | `No update`      |
+| [kube-node-common](roles/kube-node-common)     | `-`               | `No update`      |
+| [kube-control-plane](roles/kube-control-plane) | `-`               | `No update`      |
+| [kube-worker](roles/kube-worker)               | `-`               | `No update`      |
+
+## Bug fixes 🐞
+
+- [[#134](https://github.com/sighupio/installer-on-premises/pull/134)] Docker.io mirror: now configuring a mirror for docker.io does not result in an error anymore. Example, add the following vars to your Ansible `hosts.yaml` file:
+
+```yaml
+all:
+  vars:
+    containerd_registry_configs:
+      - registry: docker.io
+        mirror_endpoint:
+          - https://mymirror.mycompany/v2/docker.io
+```
+
+## Update Guide 🦮
+
+In this guide, we will try to summarize the update process to this release.
+
+### Automatic upgrade using furyctl
+
+To update using furyctl, follow this [documentation](https://docs.sighup.com/docs/installation/upgrades).
+
+### Manual update
+  
+> NOTE: Each on-premises environment can be different, always double-check before updating components.
+
+1. Update SD if applicable (see the [SD release notes](https://github.com/sighupio/distribution/tree/master/docs/releases))
+2. Update the cluster using playbooks, see the examples in this repository to know more.

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -1,4 +1,3 @@
-
 version = 2
 root = "{{ containerd_storage_dir }}"
 state = "{{ containerd_state_dir }}"
@@ -56,13 +55,11 @@ oom_score = {{ containerd_oom_score }}
       {% endfor -%}
     {% endif -%}
       [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
-        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-          endpoint = ["https://registry-1.docker.io"]
         {% if containerd_registry_configs -%}
-        {% for registry_config in containerd_registry_configs -%}
-        {% if registry_config.mirror_endpoint is defined -%}
+          {% for registry_config in containerd_registry_configs -%}
+            {% if registry_config.mirror_endpoint is defined -%}
         [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{registry_config.registry}}"]
           endpoint = {{ registry_config.mirror_endpoint }}
-        {% endif -%}
-        {% endfor -%}
+            {% endif -%}
+          {% endfor -%}
         {% endif -%}


### PR DESCRIPTION
### Summary 💡

Don't configure a default mirror for docker.io so the user can set their own and won't go in conflict.

Fixes #113

### Description 📝

We were including a mirror configuration for `docker.io` pointing to `registry-1.docker.io`, I presume because it was present in the sample configuration from upstream in the past.

This caused an isse when the user wanted to configure its own mirror for `docker.io` using the configuration options provided by the role, because the key was already in use.

Upstream does not include anymore the mirror pointing to `registry-1.docker.io` in the [sample configuration file](https://github.com/containerd/containerd/blob/v1.7.26/docs/man/containerd-config.toml.5.md#example), so I removed it.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested that running an image from the Docker Hub still works.
- [x] Tested that configuring a custom mirror for docker hub works.

### Future work 🔧

We will need eventually need to switch to the new configuration format and migrate all the in-file config for the registries to separated files because upstream is deprecating the mode we are using in 2.x.
