### PR TITLE
Add parameter to set `ipvs.strictARP` inside KubeProxyConfiguration

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,50 @@
+# On Premises module release vTBD
+
+Welcome to the latest release of `on-premises` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by SIGHUP by ReeVo team.
+
+This release adds a new feature to the `kube-control-plane` role.
+
+## Package Versions 🚢
+
+### v1.32.4-rev.2
+
+| Package                                        | Supported Version | Previous Version |
+| ---------------------------------------------- | ----------------- | ---------------- |
+| [etcd](roles/etcd)                             | `3.5.16`          | `No update`      |
+| [haproxy](roles/haproxy)                       | `3.0`             | `No update`      |
+| [containerd](roles/containerd)                 | `1.7.26`          | `No update`      |
+| [kube-node-common](roles/kube-node-common)     | `-`               | `No update`      |
+| [kube-control-plane](roles/kube-control-plane) | `-`               | `No update`      |
+| [kube-worker](roles/kube-worker)               | `-`               | `No update`      |
+
+## New features 🌟
+
+- [[#???]()]: Adds a new variable to the `kube-control-plane` role that allows setting the `ipvs.strictARP` parameter inside the KubeProxyConfiguration template.
+
+```yaml
+# hosts.yaml
+all:
+  children:
+    master:
+      vars:
+        kubernetes_strict_arp: true # default: false
+```
+
+## Bug fixes 🐞
+
+None
+
+## Update Guide 🦮
+
+In this guide, we will try to summarize the update process to this release.
+
+### Automatic upgrade using furyctl
+
+To update using furyctl, follow this [documentation](https://docs.sighup.com/docs/installation/upgrades).
+
+### Manual update
+  
+> NOTE: Each on-premises environment can be different, always double-check before updating components.
+
+1. Update SD if applicable (see the [SD release notes](https://github.com/sighupio/distribution/tree/master/docs/releases))
+2. Update the cluster using playbooks, see the examples in this repository to know more.

--- a/roles/kube-control-plane/defaults/main.yml
+++ b/roles/kube-control-plane/defaults/main.yml
@@ -4,6 +4,7 @@ kubeadm_upgrade_config_file: /etc/kubernetes/kubeadm-upgrade-config.yml
 kubeadm_patches_path: /etc/kubernetes/patches/
 kubeadm_config_path: /etc/kubernetes/kubeadm-config
 kubeadm_skip_phases: []
+kubernetes_strict_arp: false
 kubelet_config_path: /var/lib/kubelet/kubelet-config
 audit_log_dir: /var/log/kubernetes
 audit_policy_max_age: 3

--- a/roles/kube-control-plane/templates/kubeadm.yml.j2
+++ b/roles/kube-control-plane/templates/kubeadm.yml.j2
@@ -131,6 +131,7 @@ ipvs:
   minSyncPeriod: 0s
   scheduler: ""
   syncPeriod: 30s
+  strictARP: "{{ kubernetes_strict_arp }}"
 metricsBindAddress: 0.0.0.0:10249
 mode: ipvs
 ---


### PR DESCRIPTION
### Summary 💡

This PR adds a new parameter to set the `ipvs.strictARP` variable inside the `KubeProxyConfiguration` template. This is required, for example, to enable MetalLB to operate in L2 mode.

### Breaking Changes 💔

None

### Tests performed 🧪

- [ ] Tested the change with SD version X.Y.Z
- [ ] Tested an upgrade from the previous version X
