### PR TITLE
feat(containerd): expose device_ownership_from_security_context

### DIFF
--- a/docs/releases/v1.33.4.md
+++ b/docs/releases/v1.33.4.md
@@ -59,6 +59,8 @@ now users can disable repository configuration when they manage repositories ext
     - `audit_policy_max_size: 100`.
     - `audit_policy_max_backup: 10`.
 
+- [#145](https://github.com/sighupio/installer-on-premises/pull/145) **Allow setting containerd's `device_ownership_from_security_context` parameter**: the containerd role now allows to set the `device_ownership_from_security_context` parameter, needed for example when using KubeVirt.
+
 ## Breaking Changes 💔
 
 ### Kube-apiserver flags removed by upstream

--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -103,6 +103,8 @@ containerd_metrics_grpc_histogram: false
 
 containerd_max_container_log_line_size: 16384
 
+containerd_device_ownership_from_security_context: false
+
 # Kernel modules.
 containerd_modprobe:
   - { state: "present", option: "br_netfilter" }

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -18,7 +18,7 @@ oom_score = {{ containerd_oom_score }}
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ versions[kubernetes_version].sandbox_image }}"
     max_container_log_line_size = {{ containerd_max_container_log_line_size }}
-    device_ownership_from_security_context = {{ containerd_device_ownership_from_security_context }}
+    device_ownership_from_security_context = {{ containerd_device_ownership_from_security_context | string | lower }}
     [plugins."io.containerd.grpc.v1.cri".containerd]
       default_runtime_name = "{{ 'nvidia' if containerd_nvidia_enabled else 'runc' }}"
       snapshotter = "{{ containerd_snapshotter | default('overlayfs') }}"

--- a/roles/containerd/templates/config.toml.j2
+++ b/roles/containerd/templates/config.toml.j2
@@ -18,6 +18,7 @@ oom_score = {{ containerd_oom_score }}
   [plugins."io.containerd.grpc.v1.cri"]
     sandbox_image = "{{ versions[kubernetes_version].sandbox_image }}"
     max_container_log_line_size = {{ containerd_max_container_log_line_size }}
+    device_ownership_from_security_context = {{ containerd_device_ownership_from_security_context }}
     [plugins."io.containerd.grpc.v1.cri".containerd]
       default_runtime_name = "{{ 'nvidia' if containerd_nvidia_enabled else 'runc' }}"
       snapshotter = "{{ containerd_snapshotter | default('overlayfs') }}"


### PR DESCRIPTION
### Summary 💡

Expose the `device_ownership_from_security_context` parameter for containerd's configuration.

### Description 📝

Expose the `device_ownership_from_security_context` parameter from containerd, while keeping the default `false` value.
In some cases, like when using KubeVirt, it is needed to have it enabled.

### Breaking Changes 💔

None

### Tests performed 🧪

Tested with SD version v1.33.4-rc + the installer from this branch. 

- [x] Not setting the var, containerd starts up with the param set to the default value
- [x] Setting the var to `true`, containerd starts up and the param is set in the configuration file.
- [x] Setting the var to `false`, containerd starts up and the param is set in the configuration file.

### Future work 🔧

This parameter still exists in contianerd v2, with the same name and default value but it changes location in the configuration file.