### PR TITLE
refactor: refactor repository management variables

### DIFF
--- a/docs/releases/v1.33.4.md
+++ b/docs/releases/v1.33.4.md
@@ -42,13 +42,15 @@ This release adds support for Kubernetes v1.33.4, v1.32.8, v1.31.12
 
 ## New features 🌟
 
-- [[#141](https://github.com/sighupio/installer-on-premises/pull/141)] **Add package repository lifecycle management**: Add package repository lifecycle management, 
-now users can disable repository configuration when they manage repositories externally.
+- [[#141](https://github.com/sighupio/installer-on-premises/pull/141)] **Add package repository lifecycle management**: Add package repository lifecycle management,
+now users can indicate when they manage repositories externally.
 
-    New variables added:
-    - containerd role: `containerd_manage_repositories: true` to control NVIDIA repository.
-    - haproxy role: `haproxy_manage_repositories: true` to control HAProxy repository.
-    - kube-node-common role: `kubernetes_manage_repositories: true` to control Kubernetes package repository.
+    New variables added (all default to `false`, meaning repositories are managed by the installer by default):
+    - containerd role: `containerd_self_managed_repositories: false` to control NVIDIA container toolkit's repositories.
+    - haproxy role: `haproxy_self_managed_repositories: false` to control HAProxy repository.
+    - kube-node-common role: `kubernetes_self_managed_repositories: false` to control Kubernetes package repository.
+
+    Set these variables to `true` when you manage repositories externally from these playbooks.
     
 - [[#142](https://github.com/sighupio/installer-on-premises/pull/142)] **Add compliance for the CIS Kubernetes Benchmark v1.10**: introducing several security improvements following the guidelines of the CIS Benchmark v1.10. The compliance is tested using the [kube-bench tool](https://github.com/aquasecurity/kube-bench).
 

--- a/roles/containerd/defaults/main.yml
+++ b/roles/containerd/defaults/main.yml
@@ -121,8 +121,8 @@ containerd_sysctl:
   - { state: "present", name: "net.ipv4.ip_forward", value: "1" }
 
 # Repository management
-# Set to false if you manage repositories externally from these playbooks (includes NVIDIA repos when enabled)
-containerd_manage_repositories: true
+# Set to true if you manage repositories externally from these playbooks (includes NVIDIA repos when enabled)
+containerd_self_managed_repositories: false
 
 # Enable nvidia container toolkit
 containerd_nvidia_enabled: false

--- a/roles/containerd/tasks/nvidia.yml
+++ b/roles/containerd/tasks/nvidia.yml
@@ -26,8 +26,8 @@
       update_cache: true
     changed_when: false
 
-  when: 
-    - containerd_manage_repositories
+  when:
+    - not containerd_self_managed_repositories
     - ansible_os_family == 'Debian'
 
 - block:
@@ -69,8 +69,8 @@
       repo_gpgcheck: "yes"
       state: present
     notify: Clean yum cache
-  when: 
-    - containerd_manage_repositories
+  when:
+    - not containerd_self_managed_repositories
     - ansible_os_family in ['RedHat', 'Rocky']
 
 - name: Install Nvidia Container Toolkit

--- a/roles/haproxy/defaults/main.yml
+++ b/roles/haproxy/defaults/main.yml
@@ -23,5 +23,5 @@ keepalived_passphrase: "12345678"
 keepalived_virtual_router_id: "51"
 
 # Repository management
-# Set to false if you manage repositories externally from these playbooks
-haproxy_manage_repositories: true
+# Set to true if you manage repositories externally from these playbooks
+haproxy_self_managed_repositories: false

--- a/roles/haproxy/tasks/main.yml
+++ b/roles/haproxy/tasks/main.yml
@@ -37,8 +37,8 @@
 #   - https://github.com/zenetys/rpm-haproxy/issues/9
 
 - name: Ensure /etc/yum.repos.d/ exists (RHEL)
-  when: 
-    - haproxy_manage_repositories
+  when:
+    - not haproxy_self_managed_repositories
     - ansible_os_family in ['RedHat', 'Rocky']
   ansible.builtin.file:
     path: /etc/yum.repos.d/
@@ -46,8 +46,8 @@
     mode: "0755"
 
 - name: Adding Zenetys HAProxy Repo (RHEL)
-  when: 
-    - haproxy_manage_repositories
+  when:
+    - not haproxy_self_managed_repositories
     - ansible_os_family in ['RedHat', 'Rocky']
   ansible.builtin.yum_repository:
     name: zenetys
@@ -59,16 +59,16 @@
 # We need to add this repos because the official repo has outdated versions
 # https://github.com/haproxy/wiki/wiki/Packages
 - name: Adding HAProxy PPA (Ubuntu)
-  when: 
-    - haproxy_manage_repositories
+  when:
+    - not haproxy_self_managed_repositories
     - ansible_facts['distribution'] == "Ubuntu"
   ansible.builtin.apt_repository:
     repo: "ppa:vbernat/haproxy-{{ haproxy_package.Ubuntu.version }}"
     state: present
 
 - name: Adding HAProxy Repository (Debian)
-  when: 
-    - haproxy_manage_repositories
+  when:
+    - not haproxy_self_managed_repositories
     - ansible_facts['distribution'] == "Debian"
   block:
     - name: Get repo GPG key

--- a/roles/kube-node-common/defaults/main.yml
+++ b/roles/kube-node-common/defaults/main.yml
@@ -208,5 +208,5 @@ kubernetes_repo_deprecated:
   yum_gpg_key_check: "yes"
 
 # Repository management
-# Set to false if you manage repositories externally from these playbooks
-kubernetes_manage_repositories: true
+# Set to true if you manage repositories externally from these playbooks
+kubernetes_self_managed_repositories: false

--- a/roles/kube-node-common/tasks/main.yml
+++ b/roles/kube-node-common/tasks/main.yml
@@ -99,13 +99,13 @@
   when: ansible_os_family in ['RedHat', 'Rocky'] and package_list.results | length != 0
 
 - include_tasks: "repo-Rocky-RedHat.yml"
-  when: 
-    - kubernetes_manage_repositories
+  when:
+    - not kubernetes_self_managed_repositories
     - ansible_os_family in ['RedHat', 'Rocky']
 
 - include_tasks: "repo-{{ ansible_os_family }}.yml"
-  when: 
-    - kubernetes_manage_repositories
+  when:
+    - not kubernetes_self_managed_repositories
     - ansible_os_family in ['Debian']
 
 - include_tasks: node.yml


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request.

By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull
request to the best possible team for review.

💡 **TIP**
Remember that you can always open a PR in draft status and fill all the information afterwards.

Opening a PR in draft allows other team members to know that you are working on this change, and let's you have a
place to track your work in progress.

When opening PRs in Draft, **don't assign reviewers until the PR is ready for review**.

Once you are confortable with the status of the PR and all the tests and CI is green, you can assign the reviewers to start the review process.
-->

### Summary 💡

Renamed repository management variables from `*_manage_repositories` to `*_self_managed_repositories` to clarify that `true` means user manages repos externally.

<!--
If there's an existing issue for your change, please link to it below inserting a link or the issue number.

If there's _not_ an existing issue, please open one first if the problem you are solving needs to be clearly identified,
for example is an error message that other users could get and google it.
-->


<!-- If this PR is related to changes produced in other repos, like a Module, please link them below. -->
Relates: [sighupio/installer-on-premises/pull/141](https://github.com/sighupio/installer-on-premises/pull/141)


### Description 📝

Renamed fields to eliminate ambiguity:
- `containerd_manage_repositories` to `containerd_self_managed_repositories`
- `haproxy_manage_repositories` to `haproxy_self_managed_repositories`
- `kubernetes_manage_repositories` to `kubernetes_self_managed_repositories`

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Performed regression testing
- [x] Tested repos management respects the *_self_managed_repositories flags

### Future work 🔧

None.